### PR TITLE
Remove duplicate key in MIMETYPE_MAP

### DIFF
--- a/lib/formats/epub.rb
+++ b/lib/formats/epub.rb
@@ -15,7 +15,6 @@ class Peregrin::Epub
   MIMETYPE_MAP = {
     '.xhtml' => 'application/xhtml+xml',
     '.odt' => 'application/x-dtbook+xml',
-    '.odt' => 'application/x-dtbook+xml',
     '.ncx' => 'application/x-dtbncx+xml',
     '.epub' => 'application/epub+zip'
   }


### PR DESCRIPTION
Ruby 2.2 prints a warning.
